### PR TITLE
Fix Valora opening separate tab

### DIFF
--- a/src/connectors/valora/valoraUtils.ts
+++ b/src/connectors/valora/valoraUtils.ts
@@ -13,6 +13,19 @@ import { identity, mapValues } from 'lodash'
 import * as querystring from 'querystring'
 import { parse } from 'url'
 
+// Gets the url redirected from Valora that is used to update the page
+async function waitForValoraResponse() {
+  const localStorageKey = 'valoraRedirect';
+  while (true) {
+    const value = localStorage.getItem(localStorageKey);
+    if (value) {
+      localStorage.removeItem(localStorageKey);
+      return value;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+}
+
 /**
  * Parses the response from Dappkit.
  * @param url
@@ -97,6 +110,8 @@ export const requestValoraAuth = async (): Promise<AccountAuthResponseSuccess> =
       callback
     })
   )
+
+  window.location.href = await waitForValoraResponse();
   return await awaitDappkitResponse<AccountAuthResponseSuccess>()
 }
 

--- a/src/connectors/valora/valoraUtils.ts
+++ b/src/connectors/valora/valoraUtils.ts
@@ -15,14 +15,14 @@ import { parse } from 'url'
 
 // Gets the url redirected from Valora that is used to update the page
 async function waitForValoraResponse() {
-  const localStorageKey = 'valoraRedirect';
+  const localStorageKey = 'valoraRedirect'
   while (true) {
-    const value = localStorage.getItem(localStorageKey);
+    const value = localStorage.getItem(localStorageKey)
     if (value) {
-      localStorage.removeItem(localStorageKey);
-      return value;
+      localStorage.removeItem(localStorageKey)
+      return value
     }
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise(resolve => setTimeout(resolve, 100))
   }
 }
 
@@ -110,7 +110,7 @@ export const requestValoraAuth = async (): Promise<AccountAuthResponseSuccess> =
       callback
     })
   )
-  window.location.href = await waitForValoraResponse();
+  window.location.href = await waitForValoraResponse()
   return await awaitDappkitResponse<AccountAuthResponseSuccess>()
 }
 
@@ -128,7 +128,7 @@ export const requestValoraTransaction = async (txs: TxToSignParam[]): Promise<Si
       callback
     })
   )
-  window.location.href = await waitForValoraResponse();
+  window.location.href = await waitForValoraResponse()
   return await awaitDappkitResponse<SignTxResponseSuccess>()
 }
 

--- a/src/connectors/valora/valoraUtils.ts
+++ b/src/connectors/valora/valoraUtils.ts
@@ -110,7 +110,6 @@ export const requestValoraAuth = async (): Promise<AccountAuthResponseSuccess> =
       callback
     })
   )
-
   window.location.href = await waitForValoraResponse();
   return await awaitDappkitResponse<AccountAuthResponseSuccess>()
 }
@@ -129,6 +128,7 @@ export const requestValoraTransaction = async (txs: TxToSignParam[]): Promise<Si
       callback
     })
   )
+  window.location.href = await waitForValoraResponse();
   return await awaitDappkitResponse<SignTxResponseSuccess>()
 }
 

--- a/src/connectors/valora/valoraUtils.ts
+++ b/src/connectors/valora/valoraUtils.ts
@@ -89,7 +89,12 @@ export const removeQueryParams = (url: string, keys: string[]): string => {
     delete newQs[key]
   })
   const { protocol, host, hash } = parse(url)
-  return `${protocol}//${host}/${hash?.slice(0, hash.indexOf('?'))}?${querystring.stringify(newQs)}`
+  const queryParams = `${querystring.stringify(newQs)}`
+  const resultUrl = `${protocol}//${host}/${hash?.slice(0, hash.indexOf('?'))}`
+  if (queryParams) {
+    return `${resultUrl}?${queryParams}`
+  }
+  return resultUrl
 }
 
 const cleanCallbackUrl = (url: string): string => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,18 +26,17 @@ if (!!window.celo) {
   window.celo.autoRefreshOnNetworkChange = false
 }
 
-
 // Close window if search params from Valora redirect are present (handles Valora connection issue)
-const localStorageKey = 'valoraRedirect';
+const localStorageKey = 'valoraRedirect'
 if (typeof window !== 'undefined') {
   const url = window.location.href
   const whereQuery = url.indexOf('?')
   if (whereQuery !== -1) {
     const query = url.slice(whereQuery)
-    const params = new URLSearchParams(query);
+    const params = new URLSearchParams(query)
     if (params.get('type') && params.get('requestId')) {
-      localStorage.setItem(localStorageKey, window.location.href);
-      window.close();
+      localStorage.setItem(localStorageKey, window.location.href)
+      window.close()
     }
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,6 +26,22 @@ if (!!window.celo) {
   window.celo.autoRefreshOnNetworkChange = false
 }
 
+
+// Close window if search params from Valora redirect are present (handles Valora connection issue)
+const localStorageKey = 'valoraRedirect';
+if (typeof window !== 'undefined') {
+  const url = window.location.href
+  const whereQuery = url.indexOf('?')
+  if (whereQuery !== -1) {
+    const query = url.slice(whereQuery)
+    const params = new URLSearchParams(query);
+    if (params.get('type') && params.get('requestId')) {
+      localStorage.setItem(localStorageKey, window.location.href);
+      window.close();
+    }
+  }
+}
+
 const GOOGLE_ANALYTICS_IDS = {
   production: {
     [ChainId.MAINNET]: 'UA-189817928-4',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,21 +26,6 @@ if (!!window.celo) {
   window.celo.autoRefreshOnNetworkChange = false
 }
 
-// Close window if search params from Valora redirect are present (handles Valora connection issue)
-const localStorageKey = 'valoraRedirect'
-if (typeof window !== 'undefined') {
-  const url = window.location.href
-  const whereQuery = url.indexOf('?')
-  if (whereQuery !== -1) {
-    const query = url.slice(whereQuery)
-    const params = new URLSearchParams(query)
-    if (params.get('type') && params.get('requestId')) {
-      localStorage.setItem(localStorageKey, window.location.href)
-      window.close()
-    }
-  }
-}
-
 const GOOGLE_ANALYTICS_IDS = {
   production: {
     [ChainId.MAINNET]: 'UA-189817928-4',

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,6 +1,7 @@
 import React, { Suspense } from 'react'
 import { Route, Switch } from 'react-router-dom'
 import styled from 'styled-components'
+import { DappKitResponseStatus } from '@celo/utils'
 import GoogleAnalyticsReporter from '../components/analytics/GoogleAnalyticsReporter'
 import Header from '../components/Header'
 import Polling from '../components/Header/Polling'
@@ -57,7 +58,24 @@ const Marginer = styled.div`
   margin-top: 5rem;
 `
 
+const localStorageKey = 'valoraRedirect'
+
 export default function App() {
+  React.useEffect(() => {
+    // Close window if search params from Valora redirect are present (handles Valora connection issue)
+    if (typeof window !== 'undefined') {
+      const url = window.location.href
+      const whereQuery = url.indexOf('?')
+      if (whereQuery !== -1) {
+        const query = url.slice(whereQuery)
+        const params = new URLSearchParams(query)
+        if (params.get('status') === DappKitResponseStatus.SUCCESS) {
+          localStorage.setItem(localStorageKey, window.location.href)
+          window.close()
+        }
+      }
+    }
+  })
   return (
     <Suspense fallback={null}>
       <Route component={GoogleAnalyticsReporter} />


### PR DESCRIPTION
When accessing Ubeswap on Chome on Android devices, Valora redirects back to a new Ubeswap tab after connecting, causing the original Ubeswap tab to hang. The fix is inspired by https://github.com/AlexBHarley/use-contractkit/blob/master/packages/use-contractkit/src/dappkit-wallet/dappkit.ts, which stores the redirect params in `localStorage` and closes out the new tab.