### PR TITLE
Fix Valora regression on iOS

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -21,6 +21,8 @@ import RemoveLiquidity from './RemoveLiquidity'
 import { RedirectOldRemoveLiquidityPathStructure } from './RemoveLiquidity/redirects'
 import Swap from './Swap'
 import { OpenClaimAddressModalAndRedirectToSwap, RedirectPathToSwapOnly, RedirectToSwap } from './Swap/redirects'
+import { Mobile, getMobileOperatingSystem } from '../utils/mobile'
+import { useLocation } from 'react-router-dom'
 
 const AppWrapper = styled.div`
   display: flex;
@@ -61,6 +63,7 @@ const Marginer = styled.div`
 const localStorageKey = 'valoraRedirect'
 
 export default function App() {
+  const location = useLocation()
   React.useEffect(() => {
     // Close window if search params from Valora redirect are present (handles Valora connection issue)
     if (typeof window !== 'undefined') {
@@ -71,11 +74,14 @@ export default function App() {
         const params = new URLSearchParams(query)
         if (params.get('status') === DappKitResponseStatus.SUCCESS) {
           localStorage.setItem(localStorageKey, window.location.href)
-          window.close()
+          const mobileOS = getMobileOperatingSystem()
+          if (mobileOS === Mobile.ANDROID) {
+            window.close()
+          }
         }
       }
     }
-  })
+  }, [location])
   return (
     <Suspense fallback={null}>
       <Route component={GoogleAnalyticsReporter} />

--- a/src/utils/mobile.ts
+++ b/src/utils/mobile.ts
@@ -1,0 +1,26 @@
+export enum Mobile {
+  ANDROID = 'Android',
+  IOS = 'iOS',
+  OTHER = 'Other'
+}
+
+// Taken from https://stackoverflow.com/questions/21741841/detecting-ios-android-operating-system
+export function getMobileOperatingSystem() {
+  const userAgent = navigator.userAgent || navigator.vendor
+
+  // Windows Phone must come first because its UA also contains "Android"
+  if (/windows phone/i.test(userAgent)) {
+    return Mobile.OTHER
+  }
+
+  if (/android/i.test(userAgent)) {
+    return Mobile.ANDROID
+  }
+
+  // iOS detection from: http://stackoverflow.com/a/9039885/177710
+  if (/iPad|iPhone|iPod/.test(userAgent) && !window.MSStream) {
+    return Mobile.IOS
+  }
+
+  return Mobile.OTHER
+}


### PR DESCRIPTION
 - Only do window.close() on Android
   - Assumes Android always causes a new window to pop up
 - Add some mobile utils
 - Call `useEffect` in App.tsx for any location change