### PR TITLE
Increase max Hops

### DIFF
--- a/src/components/swap/routing/hooks/useTrade.ts
+++ b/src/components/swap/routing/hooks/useTrade.ts
@@ -93,7 +93,7 @@ export function useAllCommonPairsWithMoolaDuals(tokenA?: Token, tokenB?: Token):
   )
 }
 
-const MAX_HOPS = 3
+const MAX_HOPS = 4
 
 const moolaRouter: TradeRouter = {
   routerAddress: UBESWAP_MOOLA_ROUTER_ADDRESS,


### PR DESCRIPTION
*background*
i was digging into the ubeswap codebase to see if i could programmatically get prices and i noticed that the useTrade hook has a MAX_HOPS const set to 3 

however the current farming incentives mean that the best trade (assuming farms with incentives are deepest) would for many be more than 3 hops. cETH --- MOO for instance is  CETH--MCUSD--CELO--MCELO--MOO  or cMCO2 to CBTC would be CMC02--UBE--CELO--MCUSD-CBTC  both being 4 hops.  or POOF to CUER POOF-UBE-CELO-MCEUR-cEUR


*Change *
increased to 4 but wondering if 5 would be better. im sure there is a downside to having too many hops. but 4-5 seems right