### PR TITLE
Fix Total Ube Calculation

### DIFF
--- a/src/state/stake/hooks.ts
+++ b/src/state/stake/hooks.ts
@@ -560,10 +560,10 @@ export function useTotalUbeEarned(): TokenAmount | undefined {
   return useMemo(() => {
     if (!ube) return undefined
     return (
-      stakingInfos?.reduce(
-        (accumulator, stakingInfo) => accumulator.add(stakingInfo.earnedAmount),
-        new TokenAmount(ube, '0')
-      ) ?? new TokenAmount(ube, '0')
+      stakingInfos
+        ?.filter((stakingInfo) => stakingInfo.rewardToken == ube)
+        .reduce((accumulator, stakingInfo) => accumulator.add(stakingInfo.earnedAmount), new TokenAmount(ube, '0')) ??
+      new TokenAmount(ube, '0')
     )
   }, [stakingInfos, ube])
 }


### PR DESCRIPTION
Bug: The app currently crashes when you open up UbeBalanceContent to look at your total UBE rewards.

It looks like now that there are rewards that aren't just in UBE, the current logic crashes, failing the invariant for adding token amounts. This adds a check to make sure that the reward token for each stake is UBE before adding it