### PR TITLE
Show non ube reward token for external pools

### DIFF
--- a/src/components/earn/StakingModal.tsx
+++ b/src/components/earn/StakingModal.tsx
@@ -48,15 +48,15 @@ export default function StakingModal({ isOpen, onDismiss, stakingInfo, userLiqui
   const { parsedAmount, error } = useDerivedStakeInfo(typedValue, stakingInfo.stakingToken, userLiquidityUnstaked)
   const parsedAmountWrapped = parsedAmount
 
-  let hypotheticalUbeRewardRate: TokenAmount = new TokenAmount(stakingInfo.ubeRewardRate.token, '0')
-  let hypotheticalRewardRate: TokenAmount = new TokenAmount(stakingInfo.rewardRate.token, '0')
+  let hypotheticalPrimayrRewardRate: TokenAmount = new TokenAmount(stakingInfo.ubeRewardRate.token, '0')
+  let hypotheticalSecondaryRewardRate: TokenAmount = new TokenAmount(stakingInfo.rewardRate.token, '0')
   if (parsedAmountWrapped?.greaterThan('0')) {
-    hypotheticalUbeRewardRate = stakingInfo.getHypotheticalRewardRate(
+    hypotheticalPrimayrRewardRate = stakingInfo.getHypotheticalRewardRate(
       stakingInfo.stakedAmount ? parsedAmountWrapped.add(stakingInfo.stakedAmount) : parsedAmountWrapped,
       stakingInfo.totalStakedAmount.add(parsedAmountWrapped),
       stakingInfo.totalUBERewardRate
     )
-    hypotheticalRewardRate = stakingInfo.getHypotheticalRewardRate(
+    hypotheticalSecondaryRewardRate = stakingInfo.getHypotheticalRewardRate(
       stakingInfo.stakedAmount ? parsedAmountWrapped.add(stakingInfo.stakedAmount) : parsedAmountWrapped,
       stakingInfo.totalStakedAmount.add(parsedAmountWrapped),
       stakingInfo.totalRewardRate
@@ -143,21 +143,21 @@ export default function StakingModal({ isOpen, onDismiss, stakingInfo, userLiqui
             id="stake-liquidity-token"
           />
 
-          <HypotheticalRewardRate dim={!hypotheticalUbeRewardRate.greaterThan('0')}>
+          <HypotheticalRewardRate dim={!hypotheticalPrimayrRewardRate.greaterThan('0')}>
             <div>
               <TYPE.black fontWeight={600}>Weekly Rewards</TYPE.black>
             </div>
 
             <div>
               <TYPE.black>
-                {hypotheticalUbeRewardRate
+                {hypotheticalPrimayrRewardRate
                   .multiply((60 * 60 * 24 * 7).toString())
                   .toSignificant(4, { groupSeparator: ',' })}{' '}
-                UBE / week
+                {stakingInfo.ubeRewardRate.token.symbol ?? 'UBE'} / week
               </TYPE.black>
               {stakingInfo?.dualRewards && (
                 <TYPE.black>
-                  {hypotheticalRewardRate
+                  {hypotheticalSecondaryRewardRate
                     .multiply((60 * 60 * 24 * 7).toString())
                     .toSignificant(4, { groupSeparator: ',' })}{' '}
                   {stakingInfo?.rewardToken?.symbol} / week

--- a/src/components/earn/StakingModal.tsx
+++ b/src/components/earn/StakingModal.tsx
@@ -48,10 +48,10 @@ export default function StakingModal({ isOpen, onDismiss, stakingInfo, userLiqui
   const { parsedAmount, error } = useDerivedStakeInfo(typedValue, stakingInfo.stakingToken, userLiquidityUnstaked)
   const parsedAmountWrapped = parsedAmount
 
-  let hypotheticalPrimayrRewardRate: TokenAmount = new TokenAmount(stakingInfo.ubeRewardRate.token, '0')
+  let hypotheticalPrimaryRewardRate: TokenAmount = new TokenAmount(stakingInfo.ubeRewardRate.token, '0')
   let hypotheticalSecondaryRewardRate: TokenAmount = new TokenAmount(stakingInfo.rewardRate.token, '0')
   if (parsedAmountWrapped?.greaterThan('0')) {
-    hypotheticalPrimayrRewardRate = stakingInfo.getHypotheticalRewardRate(
+    hypotheticalPrimaryRewardRate = stakingInfo.getHypotheticalRewardRate(
       stakingInfo.stakedAmount ? parsedAmountWrapped.add(stakingInfo.stakedAmount) : parsedAmountWrapped,
       stakingInfo.totalStakedAmount.add(parsedAmountWrapped),
       stakingInfo.totalUBERewardRate
@@ -143,14 +143,14 @@ export default function StakingModal({ isOpen, onDismiss, stakingInfo, userLiqui
             id="stake-liquidity-token"
           />
 
-          <HypotheticalRewardRate dim={!hypotheticalPrimayrRewardRate.greaterThan('0')}>
+          <HypotheticalRewardRate dim={!hypotheticalPrimaryRewardRate.greaterThan('0')}>
             <div>
               <TYPE.black fontWeight={600}>Weekly Rewards</TYPE.black>
             </div>
 
             <div>
               <TYPE.black>
-                {hypotheticalPrimayrRewardRate
+                {hypotheticalPrimaryRewardRate
                   .multiply((60 * 60 * 24 * 7).toString())
                   .toSignificant(4, { groupSeparator: ',' })}{' '}
                 {stakingInfo.ubeRewardRate.token.symbol ?? 'UBE'} / week


### PR DESCRIPTION
Currently the staking modal always shows UBE as the reward token
# Old View:
![image](https://user-images.githubusercontent.com/14019779/131934157-3226ba31-8fd7-4b7c-8e45-7d206e8c8f78.png)

With the change, the main reward token's symbol, whatever it might be appears:

# Non-UBE Single Pool:
![image](https://user-images.githubusercontent.com/14019779/131934378-dc939ede-6815-4873-8bde-202ec70be816.png)

# UBE Single Pool:
![image](https://user-images.githubusercontent.com/14019779/131934540-8edd607e-b229-4d97-a561-d0a9d30da9a5.png)

# Dual Pool:
![image](https://user-images.githubusercontent.com/14019779/131934605-237699f6-87aa-4c76-af4c-ef4bdc7a57a6.png)

