### PR TITLE
Add Farm Button to Pool

### DIFF
--- a/src/components/PositionCard/index.tsx
+++ b/src/components/PositionCard/index.tsx
@@ -6,11 +6,13 @@ import { ChevronDown, ChevronUp } from 'react-feather'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Text } from 'rebass'
+import useStakingInfo from 'state/stake/useStakingInfo'
 import styled from 'styled-components'
 
 import { BIG_INT_ZERO } from '../../constants'
 import { useTotalSupply } from '../../data/TotalSupply'
 import { useColor } from '../../hooks/useColor'
+import { multiRewardPools } from '../../state/stake/farms'
 import { useTokenBalance } from '../../state/wallet/hooks'
 import { ExternalLink, TYPE } from '../../theme'
 import { currencyId } from '../../utils/currencyId'
@@ -189,6 +191,16 @@ export default function FullPositionCard({ pair, border, stakedBalance }: Positi
 
   const backgroundColor = useColor(pair?.token0)
 
+  const stakingInfo = useStakingInfo(pair)?.find((x) => x.active)
+
+  const multiRewards = multiRewardPools
+    .filter((multiPool) => {
+      return multiPool.active && multiPool.basePool === stakingInfo?.poolInfo?.poolAddress
+    })
+    .sort((a, b) => (a.numRewards === b.numRewards ? 0 : a.numRewards > b.numRewards ? -1 : 1))
+
+  const farmAddress = multiRewards[0]?.address ?? stakingInfo?.stakingRewardAddress
+
   return (
     <StyledPositionCard border={border} bgColor={backgroundColor}>
       <CardNoise />
@@ -319,15 +331,15 @@ export default function FullPositionCard({ pair, border, stakedBalance }: Positi
                 </ButtonPrimary>
               </RowBetween>
             )}
-            {stakedBalance && JSBI.greaterThan(stakedBalance.raw, BIG_INT_ZERO) && (
+            {farmAddress && (
               <ButtonPrimary
                 padding="8px"
                 borderRadius="8px"
                 as={Link}
-                to={`/uni/${currencyId(currency0)}/${currencyId(currency1)}`}
+                to={`/farm/${currencyId(currency0)}/${currencyId(currency1)}/${farmAddress}`}
                 width="100%"
               >
-                Manage Liquidity in Rewards Pool
+                Farm
               </ButtonPrimary>
             )}
           </AutoColumn>


### PR DESCRIPTION
### what

Add a button go directly to farm with the most rewards if one such farm exists for the pool.

### why 

I was struggling with going back and forth between the pool and farm and thought this would be a great solution for that.

### visual

![Screen Shot 2021-10-22 at 3 24 28 PM](https://user-images.githubusercontent.com/3814795/138530039-b101d8dd-de5f-4dfe-9fdb-b7edf2469e9f.png)

### other
Note this replaces some code which Seemed to be dead to me as the place it linked (uni/address) does not showup as a route in App.tsx