### PR TITLE
Move "Your Pools" to the top of Farm Page

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -26,6 +26,8 @@
   "double": "Double",
   "rewardPools": "Reward Pools",
   "yourPools": "Your Pools",
+  "yourTriplePools": "Your Triple Reward Pools",
+  "yourDoublePools": "Your Double Reward Pools",
   "availablePools": "Available Pools",
   "inactivePools": "Inactive Pools",
   "week": "week",

--- a/src/state/stake/useOwnerStakedPools.ts
+++ b/src/state/stake/useOwnerStakedPools.ts
@@ -1,0 +1,74 @@
+import { useContractKit, useProvider } from '@celo-tools/use-contractkit'
+import { JSBI } from '@ubeswap/sdk'
+import { partition } from 'lodash'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { getContract } from 'utils'
+
+import { BIG_INT_ZERO } from '../../constants'
+import DUAL_REWARDS_ABI from '../../constants/abis/moola/MoolaStakingRewards.json'
+import { MultiRewardPool, multiRewardPools } from './farms'
+import { StakingInfo } from './hooks'
+
+const isStakedPool = (pool: StakingInfo, logit = false) => {
+  return Boolean(pool.stakedAmount && JSBI.greaterThan(pool.stakedAmount.raw, BIG_INT_ZERO))
+}
+
+// get all staked pools
+export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
+  const { address: owner } = useContractKit()
+  const library = useProvider()
+
+  const [data, setData] = useState(null)
+
+  const multiRewards = useMemo(
+    () =>
+      multiRewardPools.map((multiPool) => {
+        return [multiPool, allPools.find((pool) => pool.poolInfo.poolAddress === multiPool.basePool)]
+      }) as [MultiRewardPool, StakingInfo | undefined][],
+    [allPools, multiRewardPools]
+  )
+
+  // TODO: Add balance information to multiRewardPools so we do not have to fetch again
+  const getBalanceCalls = multiRewards.map((mr) => {
+    const stakeRewards = getContract(mr[0].address, DUAL_REWARDS_ABI, library, owner || undefined)
+    const rock = new Promise((resolve, reject) => {
+      stakeRewards.callStatic.balanceOf(owner).then((data) => {
+        resolve({ [mr[0].address]: data > 0 })
+      })
+    })
+    return rock
+  })
+
+  const [stakedPools, unstakedPools] = useMemo(() => {
+    return partition(allPools, isStakedPool)
+  }, [allPools])
+
+  const load = useCallback(async () => {
+    try {
+      const results = await Promise.all(getBalanceCalls)
+      return results.reduce((pv, cv) => ({ ...pv, ...cv }), {})
+    } catch (e) {
+      return null
+    }
+  }, [getBalanceCalls])
+
+  useEffect(() => {
+    void (async () => {
+      setData(await load())
+    })()
+  }, [load])
+
+  const [stakedMultiPools, unstakedMultiPools] = partition(
+    multiRewards || [],
+    (p) => data && p[0] && p[0].address && data[p[0].address]
+  )
+
+  return { stakedMultiPools, unstakedMultiPools, stakedPools, unstakedPools }
+
+  /*
+      Return TriplePools, DualPools, SinglePools, 
+      Return stakedPools, unStakedPools
+  */
+}
+
+// Another Sort Pools

--- a/src/state/stake/useOwnerStakedPools.ts
+++ b/src/state/stake/useOwnerStakedPools.ts
@@ -9,7 +9,9 @@ import DUAL_REWARDS_ABI from '../../constants/abis/moola/MoolaStakingRewards.jso
 import { MultiRewardPool, multiRewardPools } from './farms'
 import { StakingInfo } from './hooks'
 
-const isStakedPool = (pool: StakingInfo, logit = false) => {
+type TBalanceResult = Record<string, boolean>
+
+const isStakedPool = (pool: StakingInfo) => {
   return Boolean(pool.stakedAmount && JSBI.greaterThan(pool.stakedAmount.raw, BIG_INT_ZERO))
 }
 
@@ -18,7 +20,7 @@ export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
   const { address: owner } = useContractKit()
   const library = useProvider()
 
-  const [data, setData] = useState(null)
+  const [data, setData] = useState<null | TBalanceResult>(null)
 
   const multiRewards = useMemo(
     () =>
@@ -31,12 +33,14 @@ export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
   // TODO: Add balance information to multiRewardPools so we do not have to fetch again
   const getBalanceCalls = multiRewards.map((mr) => {
     const stakeRewards = getContract(mr[0].address, DUAL_REWARDS_ABI, library, owner || undefined)
-    const rock = new Promise((resolve, reject) => {
-      stakeRewards.callStatic.balanceOf(owner).then((data) => {
-        resolve({ [mr[0].address]: data > 0 })
-      })
+    return new Promise<TBalanceResult>((resolve, reject) => {
+      stakeRewards.callStatic.balanceOf(owner).then(
+        (data) => {
+          resolve({ [mr[0].address]: data > 0 })
+        },
+        (error) => reject(error)
+      )
     })
-    return rock
   })
 
   const [stakedPools, unstakedPools] = useMemo(() => {
@@ -46,6 +50,8 @@ export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
   const load = useCallback(async () => {
     try {
       const results = await Promise.all(getBalanceCalls)
+
+      // consolidate all balances into one object
       return results.reduce((pv, cv) => ({ ...pv, ...cv }), {})
     } catch (e) {
       return null
@@ -53,9 +59,16 @@ export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
   }, [getBalanceCalls])
 
   useEffect(() => {
-    void (async () => {
-      setData(await load())
-    })()
+    let isSubscribed = true
+    load().then((balances) => {
+      if (isSubscribed) {
+        setData(balances)
+      }
+    })
+
+    return () => {
+      isSubscribed = false
+    }
   }, [load])
 
   const [stakedMultiPools, unstakedMultiPools] = partition(
@@ -64,11 +77,4 @@ export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
   )
 
   return { stakedMultiPools, unstakedMultiPools, stakedPools, unstakedPools }
-
-  /*
-      Return TriplePools, DualPools, SinglePools, 
-      Return stakedPools, unStakedPools
-  */
 }
-
-// Another Sort Pools

--- a/src/state/stake/useOwnerStakedPools.ts
+++ b/src/state/stake/useOwnerStakedPools.ts
@@ -27,7 +27,7 @@ export const useOwnerStakedPools = (allPools: StakingInfo[]) => {
       multiRewardPools.map((multiPool) => {
         return [multiPool, allPools.find((pool) => pool.poolInfo.poolAddress === multiPool.basePool)]
       }) as [MultiRewardPool, StakingInfo | undefined][],
-    [allPools, multiRewardPools]
+    [allPools]
   )
 
   // TODO: Add balance information to multiRewardPools so we do not have to fetch again


### PR DESCRIPTION
To make it easier to manage your farmed pools, this PR moves "Your Pools" to the top, sorted by "Triple Reward Pools", "Double Reward Pools", "Your Pools", and then "Your Inactive Pools"

This is done by doing the following:

1. Creating a new hook useOwnerStakedPools
2. Fetching all the balances of all the multirewardpools and checking which ones are greater than zero, so we know what is staked
3. Displaying it properly in the UI

See screencast here: https://watch.screencastify.com/v/4NyR5f6M4E0QSgQYMUB4