### PR TITLE
fix pressing max should be sendable, remove false nsf error

### DIFF
--- a/src/pages/Send/index.tsx
+++ b/src/pages/Send/index.tsx
@@ -36,7 +36,8 @@ export default function Send() {
 
   const maxAmountInput: TokenAmount | undefined = maxAmountSpend(currencyBalances[Field.INPUT])
 
-  const notEnoughFunds = parsedAmount && maxAmountInput && !parsedAmount.lessThan(maxAmountInput)
+  const notEnoughFunds = parsedAmount && maxAmountInput && parsedAmount.greaterThan(maxAmountInput)
+
   const isValid = recipientAddress && parsedAmount && account && !notEnoughFunds
   const doTransaction = useDoTransaction()
   const handleSend = useCallback(async () => {


### PR DESCRIPTION
#### Issue
Pressing "max" on the send page would show an insufficient funds message. 

#### Solution
change `!lessThan` to `greaterThan` so that `==` case does not trigger the nsf. 


https://user-images.githubusercontent.com/3814795/140854983-3dafeece-cb20-4345-b3f2-6b02f81d9ea7.mov

