### PR TITLE
Farm page minor Improvements

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -56,7 +56,6 @@ const BodyWrapper = styled.div`
 
   ${({ theme }) => theme.mediaWidth.upToSmall`
     padding: 16px;
-    padding-top: 2rem;
   `};
 
   z-index: 1;

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -47,7 +47,7 @@ const BodyWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  padding-top: 100px;
+  padding-top: 40px;
   align-items: center;
   flex: 1;
   overflow-y: auto;

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -342,7 +342,7 @@ export default function Earn() {
         {({ width }) => (
           <List
             className="no-scrollbars"
-            height={height - 200}
+            height={height - 100}
             overscanCount={20}
             itemCount={rows.length}
             itemSize={getItemSize}

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -323,13 +323,7 @@ export default function Earn() {
 
   // eslint-disable-next-line react/prop-types
   const Row = memo<{ index: number; style: React.CSSProperties }>(({ index, style }) => {
-    return (
-      <Centerer style={style}>
-        <PageWrapper gap="sm" justify="center">
-          {rows[index].element}
-        </PageWrapper>
-      </Centerer>
-    )
+    return <div style={style}>{rows[index].element}</div>
   }, areEqual)
   Row.displayName = 'PoolCardRow'
 
@@ -338,21 +332,17 @@ export default function Earn() {
   }
 
   return (
-    <List
-      className="no-scrollbars"
-      height={height * 1.3}
-      itemCount={rows.length}
-      itemSize={getItemSize}
-      width={width}
-      ref={listRef}
-    >
-      {Row}
-    </List>
+    <PageWrapper gap="sm" justify="center">
+      <List
+        className="no-scrollbars"
+        height={height / 1.3}
+        itemCount={rows.length}
+        itemSize={getItemSize}
+        width={Math.min(width - 40, 640)}
+        ref={listRef}
+      >
+        {Row}
+      </List>
+    </PageWrapper>
   )
 }
-
-const Centerer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`

--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -323,7 +323,13 @@ export default function Earn() {
 
   // eslint-disable-next-line react/prop-types
   const Row = memo<{ index: number; style: React.CSSProperties }>(({ index, style }) => {
-    return <div style={style}>{rows[index].element}</div>
+    return (
+      <Centerer style={style}>
+        <PageWrapper gap="sm" justify="center">
+          {rows[index].element}
+        </PageWrapper>
+      </Centerer>
+    )
   }, areEqual)
   Row.displayName = 'PoolCardRow'
 
@@ -332,17 +338,21 @@ export default function Earn() {
   }
 
   return (
-    <PageWrapper gap="sm" justify="center">
-      <List
-        className="no-scrollbars"
-        height={height / 1.3}
-        itemCount={rows.length}
-        itemSize={getItemSize}
-        width={Math.min(width - 40, 640)}
-        ref={listRef}
-      >
-        {Row}
-      </List>
-    </PageWrapper>
+    <List
+      className="no-scrollbars"
+      height={height * 1.3}
+      itemCount={rows.length}
+      itemSize={getItemSize}
+      width={width}
+      ref={listRef}
+    >
+      {Row}
+    </List>
   )
 }
+
+const Centerer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`

--- a/src/state/multicall/updater.tsx
+++ b/src/state/multicall/updater.tsx
@@ -146,7 +146,7 @@ export default function Updater(): null {
 
     const chunkedCalls = chunkArray(calls, CALL_CHUNK_SIZE)
 
-    if (cancellations.current?.blockNumber !== latestBlockNumber) {
+    if (cancellations.current && latestBlockNumber - cancellations.current?.blockNumber > 2) {
       cancellations.current?.cancellations?.forEach((c) => c())
     }
 


### PR DESCRIPTION

* reduce empty space at top of page
* change multicall canceler to only cancel if blocks are 2 blocks behind. This should help with loading since before any fetch that took more than 5 seconds was discarded.