### PR TITLE
Dedupes unstaked farms, showing only the one with the most rewards.

### DIFF
--- a/src/pages/Earn/index.tsx
+++ b/src/pages/Earn/index.tsx
@@ -86,8 +86,8 @@ export default function Earn() {
       {stakedFarms.length > 0 && (
         <>
           <Header>{t('yourPools')}</Header>
-          {stakedFarms.map((farmSummary, idx) => (
-            <PoolWrapper key={idx}>
+          {stakedFarms.map((farmSummary) => (
+            <PoolWrapper key={farmSummary.stakingAddress}>
               <ErrorBoundary>
                 <PoolCard farmSummary={farmSummary} />
               </ErrorBoundary>
@@ -98,8 +98,8 @@ export default function Earn() {
       {unstakedFarms.length > 0 && (
         <>
           <Header>{t('availablePools')}</Header>
-          {unstakedFarms.map((farmSummary, idx) => (
-            <PoolWrapper key={idx}>
+          {unstakedFarms.map((farmSummary) => (
+            <PoolWrapper key={farmSummary.stakingAddress}>
               <ErrorBoundary>
                 <PoolCard farmSummary={farmSummary} />
               </ErrorBoundary>

--- a/src/state/stake/useOwnerStakedPools.ts
+++ b/src/state/stake/useOwnerStakedPools.ts
@@ -44,7 +44,7 @@ function unique(farmSummaries: FarmSummary[]): FarmSummary[] {
     return { ...byLpAddress, [farm.lpAddress]: likeFarms }
   }, cache)
 
-  return Object.entries(farmsGroupedByLp).map(([_, familyFarms]) => {
+  return Object.entries(farmsGroupedByLp).map(([, familyFarms]) => {
     if (familyFarms.length === 1) {
       return familyFarms[0]
     } else {


### PR DESCRIPTION

When there are two farms for a pool this dedups so that only the best one is shown. 


Note this only dedups *unstaked* farms, my thinking there is that I dont want people worrying about where their farms went. 


Uploading Screen Recording 2021-11-13 at 12.45.56 PM.mov…

