### PR TITLE
add network to fix type issue

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,6 +119,7 @@ ReactDOM.render(
         url: 'https://app.ubeswap.org',
         icon: 'https://info.ubeswap.org/favicon.png',
       }}
+      network={CeloMainnet}
       networks={[CeloMainnet, Alfajores]}
       connectModal={{
         reactModalProps: {


### PR DESCRIPTION
fixing 

Error: src/index.tsx(114,6): error TS2741: Property 'network' is missing in type '{ children: Element; dapp: { name: string; description: string; url: string; icon: string; }; networks: ({ readonly name: NetworkNames.CeloMainnet; readonly rpcUrl: "https://forno.celo.org"; readonly graphQl: "https://explorer.celo.org/graphiql"; readonly explorer: "https://explorer.celo.org"; readonly chainId: Chai...' but required in type 'ContractKitProviderProps'