### PR TITLE
Fixes mobile nav overflow + relayout 

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -168,6 +168,9 @@ const UbeIcon = styled.div`
   :hover {
     transform: rotate(-5deg);
   }
+  @media (max-width: 385px) {
+    display: none;
+  }
 `
 
 const activeClassName = 'ACTIVE'
@@ -196,6 +199,10 @@ const StyledNavLink = styled(NavLink).attrs({
   :hover,
   :focus {
     color: ${({ theme }) => darken(0.1, theme.text1)};
+  }
+
+  @media (max-width: 320px) {
+    margin: 0 8px;
   }
 `
 
@@ -287,7 +294,12 @@ export default function Header() {
       <HeaderRow>
         <Title to="/">
           <UbeIcon>
-            <img width={isMobile ? '32px' : '140px'} src={isMobile ? Icon : darkMode ? LogoDark : Logo} alt="logo" />
+            <img
+              width={isMobile ? '32px' : '140px'}
+              height={isMobile ? '36px' : '26px'}
+              src={isMobile ? Icon : darkMode ? LogoDark : Logo}
+              alt="Ubeswap"
+            />
           </UbeIcon>
         </Title>
         <HeaderLinks>

--- a/src/components/WalletModal/Option.tsx
+++ b/src/components/WalletModal/Option.tsx
@@ -129,7 +129,7 @@ export default function Option({
         {subheader && <SubHeader>{subheader}</SubHeader>}
       </OptionCardLeft>
       <IconWrapper size={size}>
-        <img src={icon} alt={'Icon'} />
+        <img src={icon} alt={'Icon'} width={`${size || 24}px`} height={`${size || 24}px`} />
       </IconWrapper>
     </OptionCardClickable>
   )


### PR DESCRIPTION
Fixes Ubeswap Logo overflow with the nav on smaller devices by removing it and for very small devices reducing space between nav items

fixes a light house complaint about img missing height and width. this helps with reducing reflowing on render

