### PR TITLE
reduce number of versions of bn

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "@celo/wallet-walletconnect": "1.2.0",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
-    "prettier": "^2.3.0"
+    "prettier": "^2.3.0",
+    "**/bn.js": "^5.1.3"
   },
   "dependencies": {
     "@apollo/client": "^3.4.16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,22 +4937,7 @@ bmp-js@^0.1.0:
   resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
   integrity sha1-4Fpj95amwf8l9Hcex62twUjAcjM=
 
-bn.js@4.11.6:
-  version "4.11.6"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
-  integrity sha1-UzRK2xRhehP26N0s4okF0cC6MhU=
-
-bn.js@4.11.8:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
-
-bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
-
-bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2:
+bn.js@4.11.6, bn.js@4.11.8, bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.6, bn.js@^4.11.8, bn.js@^4.11.9, bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.1.3:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==


### PR DESCRIPTION
use yarn resolutions to ensure only one version of BN exists before i think i saw about 4 or 5 


According to cra-bundle-analyzer this decreases the chunk from 7.43mb to 6.99mb (parsed)

this is slightly risky since we are combining v4 and v5 

https://github.com/indutny/bn.js/releases

# before
<img width="1305" alt="Screen Shot 2021-11-15 at 6 40 50 PM" src="https://user-images.githubusercontent.com/3814795/141886061-b846ff92-a49a-4db4-9e42-758a64341209.png">


# After
<img width="1310" alt="Screen Shot 2021-11-15 at 4 38 40 PM" src="https://user-images.githubusercontent.com/3814795/141885546-fdf839fd-c9bf-4658-af67-18a1b38e82cc.png">



