### PR TITLE
Farm Manage Page Data Efficiency

### DIFF
--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -129,7 +129,7 @@ export default function Manage({
     userValueCUSD,
     userAmountTokenA,
     userAmountTokenB,
-  } = useStakingPoolValue(stakingInfo)
+  } = useStakingPoolValue(stakingInfo, stakingTokenPair)
 
   const countUpAmounts = stakingInfo?.earnedAmounts?.map((earnedAmount) => earnedAmount.toFixed(6) ?? '0') || []
   const countUpAmountsPrevious = usePrevious(countUpAmounts) ?? countUpAmounts

--- a/src/pages/Earn/useStakingPoolValue.tsx
+++ b/src/pages/Earn/useStakingPoolValue.tsx
@@ -1,7 +1,6 @@
 import { useContractKit } from '@celo-tools/use-contractkit'
-import { ChainId as UbeswapChainId, cUSD, JSBI, TokenAmount } from '@ubeswap/sdk'
+import { ChainId as UbeswapChainId, cUSD, JSBI, Pair, TokenAmount } from '@ubeswap/sdk'
 import { BIG_INT_ZERO } from 'constants/index'
-import { usePair } from 'data/Reserves'
 import { useTotalSupply } from 'data/TotalSupply'
 import { StakingInfo } from 'state/stake/hooks'
 import { useCUSDPrice } from 'utils/useCUSDPrice'
@@ -15,11 +14,13 @@ interface IStakingPoolValue {
   userAmountTokenB?: TokenAmount
 }
 
-export const useStakingPoolValue = (stakingInfo?: StakingInfo | null): IStakingPoolValue => {
+export const useStakingPoolValue = (
+  stakingInfo?: StakingInfo | null,
+  stakingTokenPair?: Pair | null
+): IStakingPoolValue => {
   const { network } = useContractKit()
   const chainId = network.chainId
   const totalSupplyOfStakingToken = useTotalSupply(stakingInfo?.stakingToken)
-  const [, stakingTokenPair] = usePair(stakingInfo?.tokens[0], stakingInfo?.tokens[1])
 
   const cusd = cUSD[chainId as unknown as UbeswapChainId]
   const cusdPrice0 = useCUSDPrice(stakingTokenPair?.token0)


### PR DESCRIPTION
pass the stakingTokenPair directly into useStakingPoolValue, otherwise it waits until the staking info is available to get the token prices but since we already have the tokens we can parallel the work



