### PR TITLE
fix earned reward amount mismatching token

### DIFF
--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -177,9 +177,9 @@ export default function Manage({
             {stakingInfo?.active && (
               <>
                 <TYPE.body style={{ margin: 0 }}>{t('poolRate')}</TYPE.body>
-                {stakingInfo?.totalRewardRates?.map((rewardRate, idx) => {
+                {stakingInfo?.totalRewardRates?.map((rewardRate) => {
                   return (
-                    <TYPE.body fontSize={24} fontWeight={500} key={idx}>
+                    <TYPE.body fontSize={24} fontWeight={500} key={rewardRate.token.symbol}>
                       {rewardRate?.multiply(BIG_INT_SECONDS_IN_WEEK)?.toFixed(0, { groupSeparator: ',' }) ?? '-'}
                       {` ${rewardRate.token.symbol} / week`}
                     </TYPE.body>
@@ -307,7 +307,7 @@ export default function Manage({
                 )}
               </RowBetween>
               {stakingInfo?.rewardRates?.map((rewardRate, idx) => (
-                <RowBetween style={{ alignItems: 'baseline' }} key={idx}>
+                <RowBetween style={{ alignItems: 'baseline' }} key={rewardRate.token.symbol}>
                   <TYPE.largeHeader fontSize={36} fontWeight={600}>
                     {countUpAmounts[idx] ? (
                       <CountUp

--- a/src/state/stake/useDualStakeRewards.ts
+++ b/src/state/stake/useDualStakeRewards.ts
@@ -102,7 +102,7 @@ export const useMultiStakeRewards = (
       poolInfo: underlyingPool.poolInfo,
       rewardTokens,
     }
-  }, [data, rewardsToken, underlyingPool, address, active])
+  }, [data, rewardsToken, underlyingPool, address, active, externalRewardsTokens])
 }
 
 // because `earned` is just a series of BigNumbers we must somehow match to the Tokens

--- a/src/state/stake/useDualStakeRewards.ts
+++ b/src/state/stake/useDualStakeRewards.ts
@@ -83,12 +83,8 @@ export const useMultiStakeRewards = (
       (a, b) => externalRewardsTokens[a?.address] - externalRewardsTokens[b?.address]
     )
     const rewardTokens = rewardsToken ? [rewardsToken, ...underlyingRewardTokens] : [...underlyingRewardTokens]
-    const earnedAmounts =
-      earned && earned.length === rewardTokens.length
-        ? zip<BigNumber, Token>(earned, rewardTokens)
-            .map(([amount, token]) => new TokenAmount(token as Token, amount?.toString() ?? '0'))
-            .sort((a, b) => (a?.token?.symbol && b?.token?.symbol ? a.token.symbol.localeCompare(b.token.symbol) : 0))
-        : undefined
+
+    const earnedAmounts = getEarnedAmounts(earned, totalRewardRates)
 
     return {
       stakingRewardAddress: address,
@@ -106,5 +102,19 @@ export const useMultiStakeRewards = (
       poolInfo: underlyingPool.poolInfo,
       rewardTokens,
     }
-  }, [data, rewardsToken, underlyingPool, address, active, externalRewardsTokens])
+  }, [data, rewardsToken, underlyingPool, address, active])
+}
+
+// because `earned` is just a series of BigNumbers we must somehow match to the Tokens
+// since the values of earned array are porportional to the value of the reward rates sort both the same way before zipzing together
+function getEarnedAmounts(earned: BigNumber[], totalRewardRates: TokenAmount[]) {
+  if (earned?.length === totalRewardRates?.length) {
+    const decendingRewardRates = totalRewardRates.slice(0).sort((a, b) => (a.lessThan(b) ? 1 : -1))
+    const descendingEarnedAmounts = earned?.sort((a, b) => (a.lt(b) ? 1 : -1))
+
+    return zip<BigNumber, TokenAmount>(descendingEarnedAmounts, decendingRewardRates)
+      .map(([amount, tokenAmount]) => new TokenAmount(tokenAmount?.token as Token, amount?.toString() ?? '0'))
+      .sort((a, b) => (a?.token?.symbol && b?.token?.symbol ? a.token.symbol.localeCompare(b.token.symbol) : 0))
+  }
+  return undefined
 }


### PR DESCRIPTION
Earned Amounts sometimes were displayed with the wrong token. Since when the array of earnings and the array of tokens were zipped together the orders were not necessarily the same. So now it sorts  both by the values first since those should match. 


Also use Token symbol not Index for keys (as thats an [anti-pattern](https://reactpatterns.js.org/docs/indexes-as-a-key-is-an-anti-pattern/))