### PR TITLE
Tighten Up reward and staking displays

### DIFF
--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -227,9 +227,9 @@ export const PoolCard: React.FC<Props> = ({ farmSummary }: Props) => {
 
 // Format amount based on the size, when under 1 show significant digits, when 1 to 10 show 1 decimal, over 10 round
 function formatStakedAmount(tokenAmmount?: TokenAmount) {
-  const amount = tokenAmmount?.lessThan(1)
+  const amount = tokenAmmount?.lessThan('1')
     ? tokenAmmount.toSignificant(2)
-    : tokenAmmount?.toFixed(tokenAmmount?.lessThan(10) ? 1 : 0, { groupSeparator: ',' })
+    : tokenAmmount?.toFixed(tokenAmmount?.lessThan('10') ? 1 : 0, { groupSeparator: ',' })
   return `${amount} ${tokenAmmount?.token.symbol}`
 }
 

--- a/src/components/earn/PoolCard.tsx
+++ b/src/components/earn/PoolCard.tsx
@@ -1,6 +1,6 @@
 import { gql, useQuery } from '@apollo/client'
 import { useContractKit } from '@celo-tools/use-contractkit'
-import { Percent } from '@ubeswap/sdk'
+import { Percent, TokenAmount } from '@ubeswap/sdk'
 import QuestionHelper from 'components/QuestionHelper'
 import { useToken } from 'hooks/Tokens'
 import { useStakingContract } from 'hooks/useContract'
@@ -210,12 +210,10 @@ export const PoolCard: React.FC<Props> = ({ farmSummary }: Props) => {
 
                 <RowFixed>
                   <TYPE.black style={{ textAlign: 'right' }} color={'white'} fontWeight={500}>
-                    ${userValueCUSD.toFixed(0, { groupSeparator: ',' })}
+                    {'$' + userValueCUSD.toFixed(0, { groupSeparator: ',' })}
                   </TYPE.black>
                   <QuestionHelper
-                    text={`${userAmountTokenA?.toFixed(0, { groupSeparator: ',' })} ${
-                      userAmountTokenA?.token.symbol
-                    }, ${userAmountTokenB?.toFixed(0, { groupSeparator: ',' })} ${userAmountTokenB?.token.symbol}`}
+                    text={`${formatStakedAmount(userAmountTokenA)} | ${formatStakedAmount(userAmountTokenB)}`}
                   />
                 </RowFixed>
               </RowBetween>
@@ -225,6 +223,14 @@ export const PoolCard: React.FC<Props> = ({ farmSummary }: Props) => {
       )}
     </Wrapper>
   )
+}
+
+// Format amount based on the size, when under 1 show significant digits, when 1 to 10 show 1 decimal, over 10 round
+function formatStakedAmount(tokenAmmount?: TokenAmount) {
+  const amount = tokenAmmount?.lessThan(1)
+    ? tokenAmmount.toSignificant(2)
+    : tokenAmmount?.toFixed(tokenAmmount?.lessThan(10) ? 1 : 0, { groupSeparator: ',' })
+  return `${amount} ${tokenAmmount?.token.symbol}`
 }
 
 // formula is 1 + ((nom/compoundsPerYear)^compoundsPerYear) - 1

--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -177,9 +177,9 @@ export default function Manage({
             {stakingInfo?.active && (
               <>
                 <TYPE.body style={{ margin: 0 }}>{t('poolRate')}</TYPE.body>
-                {stakingInfo?.totalRewardRates?.map((rewardRate, idx) => {
+                {stakingInfo?.totalRewardRates?.map((rewardRate) => {
                   return (
-                    <TYPE.body fontSize={24} fontWeight={500} key={idx}>
+                    <TYPE.body fontSize={24} fontWeight={500} key={rewardRate.token.symbol}>
                       {rewardRate?.multiply(BIG_INT_SECONDS_IN_WEEK)?.toFixed(0, { groupSeparator: ',' }) ?? '-'}
                       {` ${rewardRate.token.symbol} / week`}
                     </TYPE.body>
@@ -307,7 +307,7 @@ export default function Manage({
                 )}
               </RowBetween>
               {stakingInfo?.rewardRates?.map((rewardRate, idx) => (
-                <RowBetween style={{ alignItems: 'baseline' }} key={idx}>
+                <RowBetween style={{ alignItems: 'baseline' }} key={rewardRate.token.symbol}>
                   <TYPE.largeHeader fontSize={36} fontWeight={600}>
                     {countUpAmounts[idx] ? (
                       <CountUp

--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -318,7 +318,7 @@ export default function Manage({
                         <CountUp
                           key={countUpAmounts[idx]}
                           isCounting
-                          decimalPlaces={4}
+                          decimalPlaces={parseFloat(countUpAmounts[idx]) < 0.0001 ? 6 : 4}
                           start={parseFloat(countUpAmountsPrevious[idx] || countUpAmounts[idx])}
                           end={parseFloat(countUpAmounts[idx])}
                           thousandsSeparator={','}

--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -308,34 +308,37 @@ export default function Manage({
                   </ButtonEmpty>
                 )}
               </RowBetween>
-              {stakingInfo?.rewardRates?.map((rewardRate, idx) => (
-                <RowBetween style={{ alignItems: 'baseline' }} key={rewardRate.token.symbol}>
-                  <TYPE.largeHeader fontSize={36} fontWeight={600}>
-                    {countUpAmounts[idx] ? (
-                      <CountUp
-                        key={countUpAmounts[idx]}
-                        isCounting
-                        decimalPlaces={4}
-                        start={parseFloat(countUpAmountsPrevious[idx] || countUpAmounts[idx])}
-                        end={parseFloat(countUpAmounts[idx])}
-                        thousandsSeparator={','}
-                        duration={1}
-                      />
-                    ) : (
-                      '0'
-                    )}
-                  </TYPE.largeHeader>
-                  <TYPE.black fontSize={16} fontWeight={500}>
-                    <span role="img" aria-label="wizard-icon" style={{ marginRight: '8px ' }}>
-                      ⚡
-                    </span>
-                    {stakingInfo?.active
-                      ? rewardRate.multiply(BIG_INT_SECONDS_IN_WEEK)?.toSignificant(4, { groupSeparator: ',' }) ?? '-'
-                      : '0'}
-                    {` ${rewardRate.token.symbol} / ${t('week')}`}
-                  </TYPE.black>
-                </RowBetween>
-              ))}
+              {stakingInfo?.rewardRates
+                // show if rewards are more than zero or unclaimed are greater than zero
+                ?.filter((rewardRate, idx) => rewardRate.greaterThan(0) || countUpAmounts[idx])
+                ?.map((rewardRate, idx) => (
+                  <RowBetween style={{ alignItems: 'baseline' }} key={rewardRate.token.symbol}>
+                    <TYPE.largeHeader fontSize={36} fontWeight={600}>
+                      {countUpAmounts[idx] ? (
+                        <CountUp
+                          key={countUpAmounts[idx]}
+                          isCounting
+                          decimalPlaces={4}
+                          start={parseFloat(countUpAmountsPrevious[idx] || countUpAmounts[idx])}
+                          end={parseFloat(countUpAmounts[idx])}
+                          thousandsSeparator={','}
+                          duration={1}
+                        />
+                      ) : (
+                        '0'
+                      )}
+                    </TYPE.largeHeader>
+                    <TYPE.black fontSize={16} fontWeight={500}>
+                      <span role="img" aria-label="wizard-icon" style={{ marginRight: '8px ' }}>
+                        ⚡
+                      </span>
+                      {stakingInfo?.active
+                        ? rewardRate.multiply(BIG_INT_SECONDS_IN_WEEK)?.toSignificant(4, { groupSeparator: ',' }) ?? '-'
+                        : '0'}
+                      {` ${rewardRate.token.symbol} / ${t('week')}`}
+                    </TYPE.black>
+                  </RowBetween>
+                ))}
             </AutoColumn>
           </StyledBottomCard>
         </BottomSection>

--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -177,14 +177,16 @@ export default function Manage({
             {stakingInfo?.active && (
               <>
                 <TYPE.body style={{ margin: 0 }}>{t('poolRate')}</TYPE.body>
-                {stakingInfo?.totalRewardRates?.map((rewardRate) => {
-                  return (
-                    <TYPE.body fontSize={24} fontWeight={500} key={rewardRate.token.symbol}>
-                      {rewardRate?.multiply(BIG_INT_SECONDS_IN_WEEK)?.toFixed(0, { groupSeparator: ',' }) ?? '-'}
-                      {` ${rewardRate.token.symbol} / week`}
-                    </TYPE.body>
-                  )
-                })}
+                {stakingInfo?.totalRewardRates
+                  ?.filter((rewardRate) => !rewardRate.equalTo(0))
+                  ?.map((rewardRate) => {
+                    return (
+                      <TYPE.body fontSize={24} fontWeight={500} key={rewardRate.token.symbol}>
+                        {rewardRate?.multiply(BIG_INT_SECONDS_IN_WEEK)?.toFixed(0, { groupSeparator: ',' }) ?? '-'}
+                        {` ${rewardRate.token.symbol} / week`}
+                      </TYPE.body>
+                    )
+                  })}
               </>
             )}
           </AutoColumn>

--- a/src/pages/Earn/Manage.tsx
+++ b/src/pages/Earn/Manage.tsx
@@ -178,7 +178,7 @@ export default function Manage({
               <>
                 <TYPE.body style={{ margin: 0 }}>{t('poolRate')}</TYPE.body>
                 {stakingInfo?.totalRewardRates
-                  ?.filter((rewardRate) => !rewardRate.equalTo(0))
+                  ?.filter((rewardRate) => !rewardRate.equalTo('0'))
                   ?.map((rewardRate) => {
                     return (
                       <TYPE.body fontSize={24} fontWeight={500} key={rewardRate.token.symbol}>
@@ -310,7 +310,7 @@ export default function Manage({
               </RowBetween>
               {stakingInfo?.rewardRates
                 // show if rewards are more than zero or unclaimed are greater than zero
-                ?.filter((rewardRate, idx) => rewardRate.greaterThan(0) || countUpAmounts[idx])
+                ?.filter((rewardRate, idx) => rewardRate.greaterThan('0') || countUpAmounts[idx])
                 ?.map((rewardRate, idx) => (
                   <RowBetween style={{ alignItems: 'baseline' }} key={rewardRate.token.symbol}>
                     <TYPE.largeHeader fontSize={36} fontWeight={600}>

--- a/src/state/stake/useDualStakeRewards.ts
+++ b/src/state/stake/useDualStakeRewards.ts
@@ -102,7 +102,7 @@ export const useMultiStakeRewards = (
       poolInfo: underlyingPool.poolInfo,
       rewardTokens,
     }
-  }, [data, rewardsToken, underlyingPool, address, active])
+  }, [data, rewardsToken, underlyingPool, address, active, externalRewardsTokens])
 }
 
 // because `earned` is just a series of BigNumbers we must somehow match to the Tokens

--- a/src/state/stake/useDualStakeRewards.ts
+++ b/src/state/stake/useDualStakeRewards.ts
@@ -83,12 +83,8 @@ export const useMultiStakeRewards = (
       (a, b) => externalRewardsTokens[a?.address] - externalRewardsTokens[b?.address]
     )
     const rewardTokens = rewardsToken ? [rewardsToken, ...underlyingRewardTokens] : [...underlyingRewardTokens]
-    const earnedAmounts =
-      earned && earned.length === rewardTokens.length
-        ? zip<BigNumber, Token>(earned, rewardTokens)
-            .map(([amount, token]) => new TokenAmount(token as Token, amount?.toString() ?? '0'))
-            .sort((a, b) => (a?.token?.symbol && b?.token?.symbol ? a.token.symbol.localeCompare(b.token.symbol) : 0))
-        : undefined
+
+    const earnedAmounts = getEarnedAmounts(earned, totalRewardRates)
 
     return {
       stakingRewardAddress: address,
@@ -106,5 +102,19 @@ export const useMultiStakeRewards = (
       poolInfo: underlyingPool.poolInfo,
       rewardTokens,
     }
-  }, [data, rewardsToken, underlyingPool, address, active, externalRewardsTokens])
+  }, [data, rewardsToken, underlyingPool, address, active])
+}
+
+// because `earned` is just a series of BigNumbers we must somehow match to the Tokens
+// since the values of earned array are porportional to the value of the reward rates sort both the same way before zipzing together
+function getEarnedAmounts(earned: BigNumber[], totalRewardRates: TokenAmount[]) {
+  if (earned?.length === totalRewardRates?.length) {
+    const decendingRewardRates = totalRewardRates.slice(0).sort((a, b) => (a.lessThan(b) ? 1 : -1))
+    const descendingEarnedAmounts = earned?.sort((a, b) => (a.lt(b) ? 1 : -1))
+
+    return zip<BigNumber, TokenAmount>(descendingEarnedAmounts, decendingRewardRates)
+      .map(([amount, tokenAmount]) => new TokenAmount(tokenAmount?.token as Token, amount?.toString() ?? '0'))
+      .sort((a, b) => (a?.token?.symbol && b?.token?.symbol ? a.token.symbol.localeCompare(b.token.symbol) : 0))
+  }
+  return undefined
 }


### PR DESCRIPTION
1. Sometimes rewards end when this happens it would say 0 TOKENS / Week. now this skips except for the earned/unclaimed if the zero rewards tokens still has unclaimed rewards. 
2. If earned amount is less than 0.0001 tokens display more digits rather than rounding down to zero 
3. when displaying staked amounts show sigificant digits when amount is less than one, and 1 decimals when 1 < x < 10.

# examples 
![Screen Shot 2021-12-04 at 1 32 37 PM](https://user-images.githubusercontent.com/3814795/144725375-32b666b7-bfae-4b00-a459-717be74c130e.png)
![Screen Shot 2021-12-04 at 1 32 42 PM](https://user-images.githubusercontent.com/3814795/144725376-858fe4fc-8a30-47ac-a6e1-08f7f895685f.png)

![Screen Shot 2021-12-04 at 1 24 58 PM](https://user-images.githubusercontent.com/3814795/144725373-f481ca03-134f-4747-86d9-78ccec765064.png)
