### PR TITLE
fix: Division by 0 error when 0 is used on the add liquidity page

### DIFF
--- a/src/pages/AddLiquidity/PoolPriceBar.tsx
+++ b/src/pages/AddLiquidity/PoolPriceBar.tsx
@@ -25,13 +25,13 @@ export function PoolPriceBar({
     <AutoColumn gap="md">
       <AutoRow justify="space-around" gap="4px">
         <AutoColumn justify="center">
-          <TYPE.black>{price?.toSignificant(6) ?? '-'}</TYPE.black>
+          <TYPE.black>{noLiquidity ? '-' : price?.toSignificant(6) ?? '-'}</TYPE.black>
           <Text fontWeight={500} fontSize={14} color={theme.text2} pt={1}>
             {currencies[Field.CURRENCY_B]?.symbol} per {currencies[Field.CURRENCY_A]?.symbol}
           </Text>
         </AutoColumn>
         <AutoColumn justify="center">
-          <TYPE.black>{price?.invert()?.toSignificant(6) ?? '-'}</TYPE.black>
+          <TYPE.black>{noLiquidity ? '-' : price?.invert()?.toSignificant(6) ?? '-'}</TYPE.black>
           <Text fontWeight={500} fontSize={14} color={theme.text2} pt={1}>
             {currencies[Field.CURRENCY_A]?.symbol} per {currencies[Field.CURRENCY_B]?.symbol}
           </Text>


### PR DESCRIPTION
Fix: When 0 is used in liquidity page, there was unexpected error that says "Division by 0"
![image](https://user-images.githubusercontent.com/95660534/148705509-91c3d9ba-2bce-4c84-94ef-65cb1f08b0d8.png)

