### PR TITLE
fix: Featured Pools spelling issue

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -229,5 +229,5 @@
   "farmUBE": "Farm UBE",
   "youHaveUnclaimedRewards": "You have {{count}} farms with unclaimed rewards",
   "claimAllRewards": "Claim all rewards",
-  "featuredPools": "Featrued Pools"
+  "featuredPools": "Featured Pools"
 }


### PR DESCRIPTION
Fixed spell of "Featrued Pools" to "Featured Pools"