### PR TITLE
fix: ui issues on stake page

### DIFF
--- a/src/components/Stake/StakeInputField.tsx
+++ b/src/components/Stake/StakeInputField.tsx
@@ -6,9 +6,7 @@ import styled from 'styled-components'
 
 import useTheme from '../../hooks/useTheme'
 import { useCurrencyBalance } from '../../state/wallet/hooks'
-import { TYPE } from '../../theme'
 import { Input as NumericalInput } from '../NumericalInput'
-import { RowBetween } from '../Row'
 
 const InputRow = styled.div<{ selected: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap}
@@ -68,6 +66,27 @@ const StyledControlButton = styled.button`
     margin-right: 0.1rem;
   `};
 `
+
+const AmountWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  width: 100%;
+`
+
+const AmountDescriptionWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  width: unset;
+  cursor: pointer;
+  font-weight: 500;
+  font-size: 14px;
+  margin-bottom: 0.5rem;
+  color: ${({ theme }) => theme.text2};
+  ${({ theme }) => theme.mediaWidth.upToExtraSmall`
+    width: 100%;
+`};
+`
 const ButtonGroup = styled.div``
 
 interface StakeInputFieldProps {
@@ -107,34 +126,27 @@ export default function StakeInputField({
       <Container hideInput={hideInput}>
         {!hideInput && (
           <LabelRow>
-            <RowBetween>
+            <AmountWrapper>
               {account && (
                 <>
-                  <TYPE.body
-                    color={theme.text2}
-                    fontWeight={500}
-                    fontSize={14}
-                    style={{ display: 'inline', cursor: 'pointer' }}
-                  >
-                    {'Current Stake: ' + (stakeBalance ? stakeBalance.toFixed(2, { groupSeparator: ',' }) : '--')}
-                  </TYPE.body>
-                  <TYPE.body
-                    onClick={onMax}
-                    color={theme.text2}
-                    fontWeight={500}
-                    fontSize={14}
-                    style={{ display: 'inline', cursor: 'pointer' }}
-                  >
-                    {!hideBalance && !!currency && selectedCurrencyBalance
-                      ? (customBalanceText ?? 'Wallet Balance: ') + selectedCurrencyBalance?.toSignificant(4)
-                      : ' -'}
-                  </TYPE.body>
+                  <AmountDescriptionWrapper>
+                    <span>Current Stake:&nbsp;</span>
+                    <span>{stakeBalance ? stakeBalance.toFixed(2, { groupSeparator: ',' }) : '--'}</span>
+                  </AmountDescriptionWrapper>
+                  <AmountDescriptionWrapper>
+                    <span>Wallet Balance:&nbsp; </span>
+                    <span>
+                      {!hideBalance && !!currency && selectedCurrencyBalance
+                        ? selectedCurrencyBalance?.toSignificant(4)
+                        : '--'}
+                    </span>
+                  </AmountDescriptionWrapper>
                 </>
               )}
-            </RowBetween>
+            </AmountWrapper>
           </LabelRow>
         )}
-        <InputRow style={hideInput ? { padding: '0', borderRadius: '8px' } : {}} selected={true}>
+        <InputRow style={{ marginTop: '-0.5rem' }} selected={true}>
           {!hideInput && (
             <>
               <NumericalInput

--- a/src/components/Stake/StakeInputField.tsx
+++ b/src/components/Stake/StakeInputField.tsx
@@ -4,7 +4,6 @@ import { darken } from 'polished'
 import React from 'react'
 import styled from 'styled-components'
 
-import useTheme from '../../hooks/useTheme'
 import { useCurrencyBalance } from '../../state/wallet/hooks'
 import { Input as NumericalInput } from '../NumericalInput'
 
@@ -97,7 +96,6 @@ interface StakeInputFieldProps {
   hideBalance?: boolean
   hideInput?: boolean
   id: string
-  customBalanceText?: string
   chainId?: ChainId
   stakeBalance?: TokenAmount
   walletBalance?: TokenAmount
@@ -111,7 +109,6 @@ export default function StakeInputField({
   hideBalance = false,
   hideInput = false,
   id,
-  customBalanceText,
   stakeBalance,
   walletBalance,
 }: StakeInputFieldProps) {
@@ -119,7 +116,6 @@ export default function StakeInputField({
 
   const userBalance = useCurrencyBalance(account ?? undefined, currency ?? undefined)
   const selectedCurrencyBalance = walletBalance ?? userBalance
-  const theme = useTheme()
 
   return (
     <InputPanel id={id}>

--- a/src/pages/Stake/index.tsx
+++ b/src/pages/Stake/index.tsx
@@ -1,7 +1,7 @@
 import { useContractKit, useGetConnectedSigner } from '@celo-tools/use-contractkit'
 import { TokenAmount } from '@ubeswap/sdk'
 import { ButtonEmpty, ButtonLight, ButtonPrimary, ButtonRadio } from 'components/Button'
-import { GreyCard, YellowCard } from 'components/Card'
+import { GreyCard, LightCard } from 'components/Card'
 import { AutoColumn } from 'components/Column'
 import CurrencyLogo from 'components/CurrencyLogo'
 import { CardNoise, CardSection, DataCard } from 'components/earn/styled'
@@ -215,9 +215,9 @@ export const Stake: React.FC = () => {
           {/* <h2>Your UBE stake: {stakeBalance ? stakeBalance.toFixed(2, { groupSeparator: ',' }) : '--'} UBE</h2> */}
           {userRewardRate?.greaterThan('0') ? (
             <>
-              <YellowCard style={{ marginBottom: '16px' }}>
+              <LightCard style={{ marginBottom: '16px' }}>
                 <DescriptionWrapper>
-                  <h4 style={{ margin: '12px 0' }}>Your weekly rewards</h4>
+                  <h4 style={{ margin: '12px 0' }}>Your Weekly Rewards</h4>
                   <h4 style={{ margin: '12px 0' }}>
                     {userRewardRate
                       ? userRewardRate.multiply(BIG_INT_SECONDS_IN_WEEK).toFixed(2, { groupSeparator: ',' })
@@ -226,7 +226,7 @@ export const Stake: React.FC = () => {
                   </h4>
                 </DescriptionWrapper>
                 <DescriptionWrapper>
-                  <h4 style={{ margin: '12px 0' }}>Annual stake APR</h4>
+                  <h4 style={{ margin: '12px 0' }}>Annual Stake APR</h4>
                   <h4 style={{ margin: '12px 0' }}>
                     {apy?.multiply('100').toFixed(2, { groupSeparator: ',' }) ?? '--'}%{' '}
                   </h4>
@@ -234,15 +234,15 @@ export const Stake: React.FC = () => {
                 <DescriptionWrapper>
                   <h4 style={{ margin: '12px 0' }}>Unclaimed Rewards</h4>
                   <div style={{ display: 'flex' }}>
-                    <h4 style={{ margin: '12px 0' }}>
-                      {userRewardRate ? earned.toFixed(4, { groupSeparator: ',' }) : '--'}
-                    </h4>
                     <ButtonEmpty padding="8px" borderRadius="8px" width="fit-content" onClick={onClaimClick}>
                       {t('claim')}
                     </ButtonEmpty>
+                    <h4 style={{ margin: '12px 0' }}>
+                      {userRewardRate ? earned.toFixed(4, { groupSeparator: ',' }) : '--'}
+                    </h4>
                   </div>
                 </DescriptionWrapper>
-              </YellowCard>
+              </LightCard>
               <CommunityWrapper showBackground={true} bgColor={theme.primary1}>
                 <h3 style={{ margin: 'unset' }}>Community UBE Stake</h3>
                 <DescriptionWrapper>
@@ -254,14 +254,14 @@ export const Stake: React.FC = () => {
                   <h4 style={{ margin: 'unset' }}>{stakeBalance?.toSignificant(4)}</h4>
                 </DescriptionWrapper>
                 <ExternalLink
-                  style={{ color: 'white', textDecoration: 'underline', textAlign: 'left' }}
+                  style={{ color: 'white', textDecoration: 'underline', textAlign: 'left', fontSize: '15px' }}
                   target="_blank"
                   href="https://explorer.celo.org/address/0x00Be915B9dCf56a3CBE739D9B9c202ca692409EC/transactions"
                 >
                   View UBE Contract
                 </ExternalLink>
                 <ExternalLink
-                  style={{ color: 'white', textDecoration: 'underline', textAlign: 'left' }}
+                  style={{ color: 'white', textDecoration: 'underline', textAlign: 'left', fontSize: '15px' }}
                   target="_blank"
                   href="https://info.ubeswap.org/token/0x00be915b9dcf56a3cbe739d9b9c202ca692409ec"
                 >
@@ -304,10 +304,10 @@ export const Stake: React.FC = () => {
         <CurrencyLogo
           currency={ube}
           size={'42px'}
-          style={{ position: 'absolute', top: '30px', right: 'calc(50% + 120px)' }}
+          style={{ position: 'absolute', top: '30px', right: 'calc(50% + 112px)' }}
         />
-        <h2 style={{ textAlign: 'center', margin: '15px 0px' }}>Your UBE stake</h2>
-        <div style={{ marginTop: '10px', display: 'flex', justifyContent: 'center' }}>
+        <h2 style={{ textAlign: 'center', margin: '15px 0px 15px 6px' }}>Your UBE Stake</h2>
+        <div style={{ margin: '10px 0 0 6px', display: 'flex', justifyContent: 'center' }}>
           <div style={{ width: '100px' }}>
             <StyledButtonRadio active={staking} onClick={() => setStaking(true)}>
               Stake


### PR DESCRIPTION
fix: UI issues on stake page
- Your Weekly Rewards pod:
Background consistency: Match background color with Your Ube Stake pod, so either both beige or both gray. 
Capitalization consistency: Change "Your weekly rewards" to "Your Weekly Rewards" and "Annual stake APR" to "Annual Stake APR"
Alignment consistency: Right justify the amount of Unclaimed Rewards by moving purple Claim button either before it, or directly underneath it 

- Community UBE Stake pod:
Sizing consistency: reduce size of View UBE Contract and View UBE Chart to match Total UBE Staked and Your UBE Stake Pool Share

- Your UBE stake pod
Change title from "Your UBE stake" to "Your UBE Stake"
When viewed in vertical mobile view, the amount underneath Current Stake and Wallet Balance moves to the line below which throws off the clarity of the mirror alignment 