### PR TITLE
fix: apr mismatches in farm page

### DIFF
--- a/src/state/stake/useOwnerStakedPools.ts
+++ b/src/state/stake/useOwnerStakedPools.ts
@@ -24,10 +24,11 @@ export const useOwnerStakedPools = (farmSummaries: FarmSummary[]) => {
   }, {})
 
   const [stakedFarms, featuredFarms, uniqueUnstakedFarms, importedFarms] = useMemo(() => {
-    const [staked, unstaked] = partition(farmSummaries, (farmSummary) => isStaked[farmSummary.stakingAddress])
+    const uniqueFarmSummaries = unique(farmSummaries)
+    const [staked, unstaked] = partition(uniqueFarmSummaries, (farmSummary) => isStaked[farmSummary.stakingAddress])
     const [featuredFarms, remainingFarms] = partition(unstaked, (farmSummary) => farmSummary.isFeatured)
     const [importedFarms, availableFarms] = partition(remainingFarms, (farmSummary) => farmSummary.isImported)
-    return [staked, unique(featuredFarms), unique(availableFarms), importedFarms]
+    return [staked, featuredFarms, availableFarms, importedFarms]
   }, [farmSummaries, isStaked])
 
   return { stakedFarms, featuredFarms, unstakedFarms: uniqueUnstakedFarms, importedFarms }


### PR DESCRIPTION
We have several farms for single lp token and that's why we could see the different APRs for same pools.
So I have removed duplicated farms in the farm page and left best farms(The farm that has the highest rewards)